### PR TITLE
Format hours in padded 24h format in the range 00-23

### DIFF
--- a/src/uielements/schedule-preview.tsx
+++ b/src/uielements/schedule-preview.tsx
@@ -186,7 +186,7 @@ export function SchedulePreview({ selection }: SchedulePreviewProps) {
             const ts = visibleTrips.map(t => {
                 const update = updates?.find((u: any) => u.trip.tripId === t.tripId);
                 return <span key={t.tripId}>
-                    {`${formatTime(Math.floor(t.arrivalTime / 3600), Math.floor(t.arrivalTime % 3600 / 60))} `}
+                    {`${formatTime(Math.floor(t.arrivalTime / 3600) % 24, Math.floor(t.arrivalTime % 3600 / 60))} `}
                     {update && <span style={{ color: 'red' }}>{update.stopTimeUpdates?.[0].arrivalDelay} sec</span>}
                 </span>
             });
@@ -218,7 +218,7 @@ export function SchedulePreview({ selection }: SchedulePreviewProps) {
 }
 
 function formatTime(hours: number, minutes: number) {
-    return `${hours}:${minutes.toString().padStart(2, '0')}`;
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
 }
 
 function matchPeriod(section: ScheduleSectionT, i_date: number) {


### PR DESCRIPTION
Prints "00:08" instead of "24:08" for trips that cross midnight. Prints "01:30" instead of "25:30" similarly.

Prints "07:08" instead of "7:08".

The zero-padding is necessary for consistency. Most people would not format 8 minutes after midnight as "0:08". They would use "00:08" or "12:08a". The 24-hour format with padded zeroes is less complex, less verbose, and familiar to developers and people from most of the world.

Before:
<img width="253" height="240" alt="before" src="https://github.com/user-attachments/assets/626551dd-7504-4bc0-8281-516e4dd902fe" />

After:
<img width="241" height="238" alt="after" src="https://github.com/user-attachments/assets/8cc6a622-69bb-41f1-99e3-897594a9343b" />

Builds on #38 #39

Fixes #45
