### PR TITLE
fixes overlay-content overflows on mobile screens

### DIFF
--- a/src/uielements/report-selector.css
+++ b/src/uielements/report-selector.css
@@ -105,6 +105,7 @@
         margin: 0.5em auto;
         border-radius: 0.5em;
         padding: 0.5em;
+        box-sizing: border-box;
     }
 
     .reports {


### PR DESCRIPTION
Fix: Added a media query for screens under 600px to prevent the overlay from overflowing on mobile.
Changes:

Removed the min-width: 600px constraint on mobile
Set width to 98% so the overlay fits the screen


@kiselev-dv 
The table has 6 columns which cannot all fit on a 375px screen without sacrificing readability. Horizontal scrolling is the standard approach for data tables on mobile — but happy to take a different approach suggested.

AFTER: 
<img width="596" height="836" alt="image" src="https://github.com/user-attachments/assets/cb510cb0-d96e-4fe1-bcf7-95cd890772b1" />
