### PR TITLE
Add agent instructions and refresh docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+This file provides guidance to AI agents when working with code in this repository. `AGENTS.md` is a symlink to this file (same convention as the main Organic Maps repo). See also [README.md](README.md) (project purpose, match categories, contribution info) and [docs/component-tree.md](docs/component-tree.md) (full component/layout tree — keep it updated when moving components).
+
+## What this is
+
+A browser SPA for the Organic Maps project that visualizes and validates the matching of **GTFS public-transport stops to OpenStreetMap stops**, and helps fix mismatches: besides inspecting pre-computed match results on a map, a user can edit OSM stop tags, move stops, create new ones, and download the edits as a JOSM-compatible `.osm` file. It also previews GTFS timetables with live (GTFS-RT) delays.
+
+Data sources (no backend of its own):
+- Static match data under `DATA_BASE_URL` (`src/config.ts`: `VITE_DATA_BASE_URL` env, prod `https://pt.organicmaps.app/data` via `.env.production`, dev default `/data` proxied by Vite) — produced by the sibling `../gtfs-parser` project (separate repo).
+- Schedules API: `http://localhost:4567/v1/{schedule,updates}` in dev, `https://pt.organicmaps.app/api/v1/…` in prod (hardcoded in `schedule-preview.tsx`).
+- Live OSM data: Overpass API (per-tile stop queries) and `api.openstreetmap.org/api/0.6` (elements by id) via `src/services/OsmQuerryQueue.ts`.
+- Map tiles: OpenFreeMap "bright" style + Esri world imagery (`src/map/styling.ts`; the satellite style borrows OpenFreeMap sprite/glyphs so symbol layers keep working).
+
+Stack: Preact 10 + Vite 7 + TypeScript 5.9 (strict) + MapLibre GL 5. **Yarn 4 via corepack** (`packageManager` in package.json).
+
+## Commands
+
+```bash
+yarn dev          # Vite dev server (proxies /data -> http://localhost:8801, stripping the /data prefix)
+yarn serve-data   # http-server for ../gtfs-parser/data/match on :8801 --cors
+yarn build        # tsc -b && vite build  (type-check gates the build; also what CI runs)
+yarn preview      # serve the production build
+```
+
+CI (`.github/workflows/build.yml`) runs `yarn install --immutable && yarn build` on every push/PR. `yarn deploy` runs `./scripts/deploy.sh` — `scripts/` is deliberately gitignored (local-only), so don't rely on it. Deployment is Cloudflare static assets from `./dist` (`wrangler.jsonc`); a custom Vite plugin (`selectiveOutDirCleanup` in `vite.config.ts`) preserves `dist/data` across builds so match data can be colocated.
+
+There are no tests and no ESLint. The only static check is `tsc -b`. The `tsconfig`s are strict and include `noUnusedLocals`/`noUnusedParameters`/`noFallthroughCasesInSwitch`, so dead code and unused params **fail the build** — clean these up rather than leaving them.
+
+## Data contract (the heart of the app)
+
+- `GET {DATA_BASE_URL}/match-report.json?t=<now>` → `{ matchedRegions: Report[], foldByName: string[] }` — region list with per-region `matchStats`, `idTags` (which OSM tags hold GTFS ids, with counts — drives the editor's Set Id/Code defaults), `matchMeta` (timestamps, bbox, sources), `liveUpdates`; `foldByName` holds region-name prefixes the report table folds into groups. See `Report` in `src/uielements/report.tsx`. (There is no separate update-report.json anymore.)
+- `GET {DATA_BASE_URL}/{region}/index.tsv?t=<now>` → one row per GTFS stop: `id, status (m|…), code, type, lon, lat, byteStart, byteEnd, search_terms(ignored)`. `code` is the 3-letter sub-category (`status_detailed`), `type` picks the detail file.
+- Stop details are **NDJSON fetched with HTTP `Range` headers**: `type` → `matches.ndjson` / `clusters.ndjson` / `no-osm.ndjson` (`fileFor` in `report.tsx`), byte offsets from the index row. The detail JSON becomes the selected feature's properties.
+- `GET {DATA_BASE_URL}/{region}/routes.ndjson` → route index (with `byteOffset`/`byteLength`); `route-stops.ndjson` is then Range-fetched per route for variants + polylines (`route-list.tsx`, with module-level promise caches).
+- `GET {DATA_BASE_URL}/{region}/preview.geojson` → stops for the timetable-preview overlay.
+- Schedules API: `GET …/schedule/{stopId}` returns `formatVersion: '4'` — a compact stop-centric format (deduplicated arrays, VLQ/base64url `pos` blobs, bit-vector service periods) decoded by `src/services/ScheduleEncoding.ts`; the format is documented in `src/services/schedule.types.d.ts`. `GET …/updates/{stopId}` (GTFS-RT delays) is polled every 5 s only when `feedMeta.liveUpdates`, and gives up after 3 errors.
+
+**Match categories** are keyed by the 3-letter `code`: `CATEGORIES` in `report.tsx` (group matched/not-matched, label, color, help) and `MATCH_LABELS` in `selection-info.tsx`. Adding/renaming a category means touching both, and the pipeline that writes index.tsv.
+
+GeoJSON feature `properties` carry nested data **as JSON strings** (e.g. `osmFeatures`, `gtfsFeatures`, `gtfsRoutes`). `stringifyProperties` in `report.tsx` enforces this when a feature flows into selection state, and the panels `JSON.parse` it back (`parseJsonSafe`). Preserve this string-encoding when adding fields — MapLibre feature properties can't hold nested objects.
+
+Gotcha: in `matchMeta.gtfsBbox`, `top` is the **south** latitude and `bottom` the north (see `region-markers.tsx`).
+
+## Architecture
+
+Component/layout tree, side-panel tabs, and context consumers are documented in [docs/component-tree.md](docs/component-tree.md). The essentials:
+
+**Global state** (`src/app.tsx`):
+- `MapContext` → `{ map, loaded: Promise<Map>, layerControls }`. Await `loaded` before adding images/overlays — don't race `map.loaded()`.
+- `SelectionContext` → `{ selection, selectionSource, updateSelection(sel, source), onReportSelect }`. `selectionSource` (`'map-click' | 'url-hash' | …`) matters: e.g. only `url-hash` selections trigger a flyTo.
+- `OSM_DATA` (`src/services/OSMData.ts`) — singleton store of live OSM elements + tracked edits (create node with negative id, move, change tags), consumed via `subscribe` + `useSyncExternalStore`. `OSM_QUERY_QUEUE` fills it from Overpass (z16 tiles, deduped, 1 s throttle) and the OSM API.
+
+**Hash routing, bidirectionally synced** (`src/uielements/routing.ts`):
+- URL shape: `#/match-report/{region}` plus `/selection/{id}` or `/preview/{id}`. The category is **not** in the URL — deep links recover it from the region's index.tsv row.
+- `useHash()`/`useHashRoute(parser)` are the read direction; a `useEffect` on `selection` in `app.tsx` writes the hash. Keep both directions in mind when touching selection logic.
+- Cross-component signal: `onReportSelect` dispatches a `ShouldUpdateBounds` window event; `report.tsx` listens at module level to arm a one-shot `fitBounds` to the region bbox.
+
+**Map rendering:**
+- `src/map/map.ts` `createMap()` builds the MapLibre instance, persists viewport to `localStorage['map-location']`, exposes `window.map` / `window.layerControls` for console debugging, and wires the `#map-style-button` / `#map-location` DOM that `MapTools` renders (it works because `createMap` runs in a post-render `useEffect`).
+- `LayerControls` (`src/map/layers-controls.ts`) swaps base styles (`cycleBaseStyle`) while re-applying registered overlays; everything map-drawn goes through `addOverlayImmediate`/`removeOverlayImmediate` so it survives style switches.
+- `StopsLayer` (`report.tsx`) is **one** source/symbol layer for all of a region's stops; category toggles use `map.setFilter` on `subcategory` (never rebuild the source), icons are data-driven `stop-{code}` images recolored from `/stop-var.svg` by `loadSvgWithColors`. It also mutates the stored overlay spec's `filter` in place so base-style switches re-apply the current filter.
+- Render-less overlay components follow one idiom: build the overlay spec, `mapLoaded.then(...)` guarded by a `subscription = { canceled, promiseFulfiled }` object, clean up in the effect teardown. See `StopsLayer`, `DatasetMapLayer` (preview), `RegionMarkersLayer`, `MatchArrowLayer`, `RoutesMap` (which instead keeps a persistent `routes` source and `setData`s into it), `HtmlMapMarker` (`editor/map-marker.tsx`).
+
+**Selection panel** (`selection-info.tsx`): unified `MatchInfo` for all categories (clusters are just `gtfsFeatures.length > 1`), with `RouteList` (route pills + variants drawn via `RoutesMap`), match arrows, distances (`src/map/distance.ts`), and the editor: `TagEditor` (`editor/osm-tags.tsx`), Set Name/Id/Code quick actions, `MoveController`, `AddOsmStopController` (creates a node with proper PT tags per route type), plus "Surrounding OSM Features" from Overpass within 500 m. Edits accumulate in `OSM_DATA.changes`; the Changes tab (`editor/changes.tsx`) exports them as `gtfs-changes.osm` (JOSM-loadable XML). An `mtch` field on an OSM candidate warns it is already matched to another GTFS stop.
+
+## Conventions
+
+- **Preact, not React.** `react`/`react-dom` are aliased to `preact/compat` (tsconfig paths + `@preact/preset-vite`). Import hooks from `preact/hooks`; `useSyncExternalStore`/`createPortal` come from `preact/compat`.
+- Debug logging is guarded: `import.meta.env.DEV && console.log(...)`. Bare `console.warn/error` only for real problems. Follow this, not the older unguarded style.
+- Render-less effect components are the pattern for imperative MapLibre objects — set up in `useEffect`, return a cleanup, use the `subscription.canceled` guard around async setup. Don't mutate the map ad hoc.
+- Module-level promise caches for per-region fetches (`route-list.tsx`) and singletons for services (`OSM_DATA`, `OSM_QUERY_QUEUE`).
+- Types use a `…T` suffix (`SelectionT`, `FeedMetaT`); newer service types drop it (`Schedule`, `OSMElement`) — match the file's neighbors. `cls()` (`uielements/cls.ts`) joins conditional class names.
+- No formatter is configured; indentation varies by file (2 spaces in `app.tsx`, 4 in most others) — match the file you're editing.
+- Comments should be brief, explaining only reasoning that is not obvious from the code itself.
+- A few `@ts-ignore`s exist around MapLibre's style typings; that's tolerated there, not an invitation to add more elsewhere.
+
+## Error handling policy
+
+Match data comes from our own pipeline and is trusted: fail visibly in the console rather than adding defensive fallbacks or schema validation for inputs that can only be wrong due to a pipeline bug (`parseJsonSafe` exists only for genuinely optional properties). Third-party live services (Overpass, OSM API, schedules API) **do** get guarded: catch, log, and degrade (see the trip-updates 3-strike cutoff and `OsmQuerryQueue`'s try/catch + throttle) — never hammer them in a retry loop.
+
+## Main focus
+
+- Simplicity and less code: prefer the smallest change that works; no new dependencies (the runtime deps are exactly `preact` and `maplibre-gl` — even XML encoding is hand-rolled) or state/router libraries.
+- Performance on big regions: thousands of stops ride in one filtered source; details, routes, and schedules are lazy (Range requests, promise caches, compact encodings). Keep new data paths lazy too, and clean up overlays/markers on unmount.
+- Keep `docs/component-tree.md` in sync when adding/moving components.
+
+## Commits and pull requests
+
+- Summary in imperative mood, max ~120 chars; separate subject from body with a blank line; explain what and why, not how, briefly.
+- Keep PRs focused and small, with brief descriptions; split unrelated changes.
+- Validate all findings and proposals on the existing codebase if applicable.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose of this project
 
-In order to display GTFS stops on the map without doubling ond visual clutter
+In order to display GTFS stops on the map without doubling and visual clutter
 we need to match GTFS stops to OSM stops.
 
 This UI displays matching results in more convenient way.
@@ -55,45 +55,60 @@ Please take a look what tag is considered appropriate by the local community.
 
 Typical tags are `<agency>_ref`, `gtfs:id`, `gtfs:stop_id`, `gtfs:stop_code`, etc.
 
-At this moment the quickest way to do so is to use `Goto OSM` button to open the
-current view on OSM and use `Id` or `JOSM` editor via `Edit` button
-to add above mentioned data to OSM stops or create it.
+One way to do so is to use the `Goto OSM` button to open the
+current view on OSM and use the `Id` or `JOSM` editor via the `Edit` button
+to add above mentioned data to OSM stops or create them.
+
+Alternatively, use the built-in editor: enable `Edit` on an OSM element in the
+selection panel to change its tags (with `Set Name` / `Set Id` / `Set Code`
+shortcuts), `Move` it, or use `Add OSM Stop` to create a missing one. Collected
+edits are listed in the `OSM Changes` tab and can be downloaded as a
+JOSM-compatible `.osm` file for review and upload.
 
 
 ### match-id
-This stops were matched by GTFS stop ID or Code.
-That means that one of the osm element tags have exact match with GTFS stop ID or Code.
+These stops were matched by GTFS stop ID or Code.
+That means that one of the OSM element tags has an exact match with the GTFS stop ID or Code.
 Usually this is some kind of a ref tag.
 
+### match-routes
+These stops were matched by the routes going through them.
+
 ### match-name
-This stops were matched by name and type and didn't get into a cluster of matches.
-Names are getting normalised: Special characters removed, lowercase, diacritics removed,
-ß converted to ss etc. Names are checked against *name* elemnt tags.
+These stops were matched by name and type and didn't get into a cluster of matches.
+Names are getting normalised: special characters removed, lowercase, diacritics removed,
+ß converted to ss etc. Names are checked against *name* element tags.
 Cluster of matches in this context means that more than one GTFS stop matched to the same OSM element.
 
-### separated-clusters
-This dataset contains matches that were successfuly separated from clusters.
+### name-id-conflict
+These stops were matched by name, but the GTFS ID or Code did not match.
+
+### match-generic
+These stops were matched to a nearby OSM stop that has no name or code to compare against.
+
+### separated-cluster
+This sub-category contains matches that were successfully separated from clusters.
 At this moment cluster separation is done by distance.
 
-In general this features considered matched. It's possible that stop matches where separated from the cluster incorrectly.
-To fix this type of an error add GTFS `id` or `code` to osm stop.
+In general these features are considered matched. It's possible that stop matches were separated from the cluster incorrectly.
+To fix this type of an error add GTFS `id` or `code` to the OSM stop.
 
-### transit-hub-clusters
-This are clusters which contains one and only one OSM element
-representing trunsport hub, such as `amenity=bus_station`, `railway=station`, etc.
+### transit-hub
+These are clusters which contain one and only one OSM element
+representing a transport hub, such as `amenity=bus_station`, `railway=station`, etc.
 and any number of stops or platforms.
 
 ### many-to-one
-This are clusters where multiple GTFS stops were matched to excatly one OSM element.
+These are clusters where multiple GTFS stops were matched to exactly one OSM element.
 
-### clusters
-This are clusters which the tool was unable to separate.
+### cluster
+These are clusters which the tool was unable to separate.
 
-### no-match and no-osm-stops
+### no-match and no-osm
 
-This two categories are simmilar in that they both contain stops
-that were not matched to OSM element. But in case of `no-osm-stops`
-means that no OSM element of the appropiate type
+These two categories are similar in that they both contain stops
+that were not matched to any OSM element. But `no-osm`
+means that no OSM element of the appropriate type
 was found at all within 750m (1000m for rail transport) radius.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## Purpose of this project
 
-In order to display GTFS stops on the map without doubling and visual clutter
+In order to display GTFS stops on the map without duplicates and visual clutter
 we need to match GTFS stops to OSM stops.
 
-This UI displays matching results in more convenient way.
+This UI displays matching results in a more convenient way.
 
 There are several sets of matched (not matched) stops,
 with different level of confidence and different ways of improving matching.

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ These stops were matched by the routes going through them.
 
 ### match-name
 These stops were matched by name and type and didn't get into a cluster of matches.
-Names are getting normalised: special characters removed, lowercase, diacritics removed,
-ß converted to ss etc. Names are checked against *name* element tags.
+Names are normalised: special characters and diacritics are removed, names are lowercased,
+ß is converted to ss, etc. Names are checked against *name* element tags.
 Cluster of matches in this context means that more than one GTFS stop matched to the same OSM element.
 
 ### name-id-conflict

--- a/docs/component-tree.md
+++ b/docs/component-tree.md
@@ -14,23 +14,27 @@ App  (src/app.tsx)
         │   │   │   (src/uielements/schedule-preview.tsx)
         │   │   └── SelectionInfo  [otherwise]
         │   │       (src/uielements/selection-info.tsx)
-        │   │       ├── MatchInfo  [per selected feature]
-        │   │       │   ├── RoutesMap  (src/uielements/routes.tsx)
-        │   │       │   ├── OsmElements
-        │   │       │   │   └── OsmListElement  [per OSM element]
-        │   │       │   │       └── TagsTable
-        │   │       │   ├── TagEditor  (src/uielements/editor/osm-tags.tsx)
-        │   │       │   └── DatasetHelp
-        │   │       ├── HtmlMapMarker  (src/uielements/editor/map-marker.tsx)
-        │   │       ├── AddOsmStopController  (src/uielements/editor/add-stop-controller.tsx)
-        │   │       └── MoveController  (src/uielements/editor/move-stop-controller.tsx)
+        │   │       └── MatchInfo  [per selected feature]
+        │   │           ├── DatasetHelp
+        │   │           ├── MatchArrowLayer  (src/uielements/match-arrow.tsx)  [GTFS→OSM arrows on map, matched categories only]
+        │   │           ├── HtmlMapMarker  (src/uielements/editor/map-marker.tsx)  [per GTFS feature, clusters only]
+        │   │           ├── RouteList  (src/uielements/route-list.tsx)  [route pills + variants]
+        │   │           │   └── RoutesMap  (src/uielements/routes.tsx)  [setData into persistent 'routes' map source]
+        │   │           ├── AddOsmStopController  (src/uielements/editor/add-stop-controller.tsx)
+        │   │           └── OsmElements  [matched + new + surrounding (Overpass, <500 m) elements]
+        │   │               ├── OsmListElement  [per OSM element]
+        │   │               │   ├── TagsTable  [view mode]
+        │   │               │   └── TagEditor  (src/uielements/editor/osm-tags.tsx)  [edit mode]
+        │   │               │       └── [Set Name | Set Id | Set Code | MoveController (editor/move-stop-controller.tsx)]
+        │   │               └── HtmlMapMarker  [per OSM / Overpass element]
         │   │
         │   ├── [tab: report]  (always mounted to keep map layers active)
         │   │   └── MatchReportSelector  (src/uielements/report-selector.tsx)
         │   │       ├── RegionMarkersLayer  [when no report selected — region circles/bboxes on map]
-        │   │       ├── ReportTable  [when no report selected]
+        │   │       ├── ReportTable  [when no report selected]  (src/uielements/report-table.tsx)
         │   │       └── MatchReport  [when report region in URL hash]  (src/uielements/report.tsx)
-        │   │           └── DatasetMapLayer  [per loaded dataset, renders into map via MapContext]
+        │   │           ├── StopsLayer  [all index.tsv stops in one symbol layer; sub-categories toggled via map.setFilter]
+        │   │           └── DatasetMapLayer  [preview.geojson overlay, only when Preview is enabled]
         │   │
         │   └── [tab: changes]
         │       └── Changes  (src/uielements/editor/changes.tsx)
@@ -39,7 +43,7 @@ App  (src/app.tsx)
             ├── MapTools  (src/uielements/map-tools.tsx)  [floating panel, top-right of map]
             │   ├── map-tools-toggle  ◀/▶ fold button
             │   ├── [map-tools-content: Help | Map Style | Location input + Goto OSM]
-            │   └── ReportHelpOverlay  [conditional: showHelp]
+            │   └── ReportHelpOverlay  [conditional: showHelp, portals into document.body]
             └── #map-view  (MapLibre GL canvas)
 ```
 
@@ -66,8 +70,8 @@ App  (src/app.tsx)
 
 | Context | Provider | Consumers |
 |---|---|---|
-| `MapContext` | `App` | `MatchReport`, `DatasetMapLayer`, `RegionMarkersLayer`, `RoutesMap`, `SelectionInfo` |
-| `SelectionContext` | `App` | `MatchReportSelector`, `MatchReport` |
+| `MapContext` | `App` | `MatchReport`, `StopsLayer`, `DatasetMapLayer`, `RegionMarkersLayer`, `RoutesMap`, `MatchArrowLayer`, `HtmlMapMarker`, `LocateMe`, `AddOsmStopController`, `MoveController` |
+| `SelectionContext` | `App` | `MatchReport`, `SelectionInfo`, `OsmListElement` |
 
 ## OSMData event system
 

--- a/src/uielements/report-help-overlay.tsx
+++ b/src/uielements/report-help-overlay.tsx
@@ -6,56 +6,65 @@ export function ReportHelpOverlay({ onClose }: { onClose: () => void }) {
             <div className={'overlay-content'}>
                 <span className={'link-like'} onClick={onClose}>Close</span>
                 <p>
-                    Main goal of this tool is to link GTFS stops to OSM stop.
+                    Main goal of this tool is to link GTFS stops to OSM stops.
 
-                    Otherwise map would be cluttered with stps from different sources.
+                    Otherwise the map would be cluttered with stops from different sources.
                 </p>
                 <p>
                     There are different ways how to establish that match with different level of confidence.
-                    Different sets shows different groups of matches or errors if tool can't match
+                    Different sub-categories show different groups of matches or errors if the tool can't match
                     GTFS and OSM stop with enough confidence.
                 </p>
                 <p>
                     <ul>
                         <li>match-id -
-                            This stops were matched by GTFS stop ID or Code.
-                            That means that one of the osm element tags have exact match
-                            with GTFS stop ID or Code.
+                            These stops were matched by GTFS stop ID or Code.
+                            That means that one of the OSM element tags has an exact match
+                            with the GTFS stop ID or Code.
 
                             Usually this is some kind of a ref tag.
                         </li>
+                        <li>match-routes -
+                            These stops were matched by the routes going through them.
+                        </li>
                         <li>match-name -
-                            This stops were matched by name and type and didn't get into a cluster of matches.
-                            Names are getting normalised: Special characters removed,
+                            These stops were matched by name and type and didn't get into a cluster of matches.
+                            Names are getting normalised: special characters removed,
                             lowercase, diacritics removed, ß converted to ss etc.
 
-                            Names are checked against *name* elemnt tags.
+                            Names are checked against *name* element tags.
 
                             <p>
                                 Cluster of matches in this context means that
                                 more than one GTFS stop matched to the same OSM element.
                             </p>
                         </li>
+                        <li>name-id-conflict -
+                            These stops were matched by name, but the GTFS ID or Code did not match.
+                        </li>
+                        <li>match-generic -
+                            These stops were matched to a nearby OSM stop that has no name or code to compare against.
+                        </li>
                         <li>separated-cluster -
-                            This sub-category contains matches that were successfuly separated from clusters.
+                            This sub-category contains matches that were successfully separated from clusters.
 
                             At this moment cluster separation is done by distance.
                         </li>
-                        <li>transit-hub -
-                            This are clusters which contains one and only one OSM element representing trunsport hub,
-                            such as amenity=bus_station, railway=station, etc. and any number of stops or platforms.
+                        <li>cluster -
+                            These are clusters which the tool was unable to separate.
                         </li>
                         <li>many-to-one -
-                            This are clusters where multiple GTFS stops were matched to excatly one OSM element.
+                            These are clusters where multiple GTFS stops were matched to exactly one OSM element.
                         </li>
-                        <li>cluster -
-                            This are clusters which the tool was unable to separate.
+                        <li>transit-hub -
+                            These are clusters which contain one and only one OSM element representing a transport hub,
+                            such as amenity=bus_station, railway=station, etc. and any number of stops or platforms.
                         </li>
                         <li>no-match -
-                            This are GTFS stops that were not matched to any OSM element.
+                            These are GTFS stops that were not matched to any OSM element.
                         </li>
                         <li>no-osm -
-                            This are GTFS stops for which no OSM element of the appropiate type was found.
+                            These are GTFS stops for which no OSM element of the appropriate type was found.
                         </li>
                     </ul>
                 </p>


### PR DESCRIPTION
## What changed

**Commit 1 — agent instructions**
- `CLAUDE.md`: guidance for AI coding agents — data contract (index.tsv + NDJSON Range fetches, routes, schedule format v4), architecture, conventions, error-handling policy. `AGENTS.md` is a symlink to it (same convention as the main Organic Maps repo).

**Commit 2 — docs refresh to match the current code**
- README + in-app Help overlay: added the missing match categories (`match-routes`, `name-id-conflict`, `match-generic`), renamed categories to the current UI labels (`separated-cluster`, `transit-hub`, `cluster`, `no-osm`), documented the built-in OSM editor workflow (edit/move/add stop → download `.osm` from the OSM Changes tab), fixed typos.
- `docs/component-tree.md`: added `RouteList` and `MatchArrowLayer`, corrected editor component placement, replaced the retired per-dataset layer model with `StopsLayer`, refreshed the context consumers table.

## Testing

`yarn build` (tsc + vite) passes. Doc content was verified against the sources; category names and descriptions come from `CATEGORIES`/`MATCH_LABELS` in the code.

Written with an LLM agent, reviewed by me.